### PR TITLE
adding NY Times search for Ukraine War articles

### DIFF
--- a/NYTimes_API-Copy1.ipynb
+++ b/NYTimes_API-Copy1.ipynb
@@ -1,0 +1,100 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bd8c30e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "from config import nytimes_api_key\n",
+    "\n",
+    "# Import the time library and the datetime module from the datetime library \n",
+    "import time\n",
+    "from datetime import datetime\n",
+    "import dateutil\n",
+    "import pandas as pd\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "343d42a6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "query = \"Ukrainian War\"\n",
+    "api = f\"https://api.nytimes.com/svc/search/v2/articlesearch.json?q={query}&api-key={nytimes_api_key}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "50ba2cb3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(api).json()\n",
+    "articles = response['response']['docs']\n",
+    "print(articles)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "546799ff",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def parse_response(response):\n",
+    "    '''Parses and returns response as pandas data frame.'''\n",
+    "    data = {'headline': [],  \n",
+    "        'date': [], \n",
+    "        'snippet': []}\n",
+    "    \n",
+    "    articles = response['response']['docs'] \n",
+    "    for article in articles:\n",
+    "        date = dateutil.parser.parse(article['pub_date']).date()\n",
+    "        \n",
+    "        data['date'].append(date)\n",
+    "        data['headline'].append(article['headline']['main'])\n",
+    "        data['snippet'].append(article['snippet'])\n",
+    "                \n",
+    "    return pd.DataFrame(data)\n",
+    "\n",
+    "nyt_df = parse_response(response)\n",
+    "nyt_df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "5d56671e",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "mlenv",
+   "language": "python",
+   "name": "mlenv"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.13"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
REQUIRE create a config.py with NYTimes API key
Please create your own config.py file with a NYTimes API key.
You can create one here:  https://developer.nytimes.com/get-started

Click on your e-mail address in the upper-right corner.
Select Apps in the drop-down menu that appears.
Select +NEW APP on your Apps page.
Enter any name and description.
Activate the Search API.
Select Create.
Take note of your just registered app’s API key. This is the only piece of information we need to get data from The New York Times, and we will need it soon.